### PR TITLE
allow airborne AccelerateX

### DIFF
--- a/src/player.asm
+++ b/src/player.asm
@@ -287,7 +287,7 @@ SetTargetVelocityX:
 ; ------------------------------------------------------------------------------
 AccelerateX:
   ld a, [bMotionState]
-  cp STATE_AIRBORNE
+  cp STATE_IDLE
   jr nz, .accelerate
 .airborne
   ld a, [fTargetVelocityX]


### PR DESCRIPTION
## Description

Allows the player to accelerate horizontally (`AccelerateX`) while airborne, resulting in a much better platforming experience.

**Before:**

https://github.com/NesHacker/GameBoyDev/assets/1747414/8dc04dc7-974a-4dab-800b-39c4022c28c0

**After:**

https://github.com/NesHacker/GameBoyDev/assets/1747414/96afbc46-50eb-4a0a-b510-72eeae5292bd