### PR TITLE
Run build task before running emulator

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,7 @@
       "type": "emulicious-debugger",
       "request": "launch",
       "name": "Launch in Emulicious",
+      "preLaunchTask": "Build",
       // "program": "${workspaceFolder}/${command:AskForProgramName}",
       "program": "${workspaceFolder}/bin/GameBoyDev.gb",
       "port": 58870,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,6 @@
       "request": "launch",
       "name": "Launch in Emulicious",
       "preLaunchTask": "Build",
-      // "program": "${workspaceFolder}/${command:AskForProgramName}",
       "program": "${workspaceFolder}/bin/GameBoyDev.gb",
       "port": 58870,
       "stopOnEntry": true


### PR DESCRIPTION
Just added this so F5 would update the rom before starting emulicious. Mostly for my own lazyness. Feel free to decline if I'm misunderstanding the build process. (Thanks for setting all this up!)