### PR TITLE
update makefiles to work with latest rgbds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ROM = $(BINDIR)/$(ROMNAME).$(ROMEXT)
 # Argument constants
 INCDIRS  = src/ src/include/ src/bin/
 WARNINGS = all extra
-ASFLAGS  = -v -L -p $(PADVALUE) $(addprefix -i,$(INCDIRS)) $(addprefix -W,$(WARNINGS))
+ASFLAGS  = -v -p $(PADVALUE) $(addprefix --include ,$(INCDIRS)) $(addprefix -W,$(WARNINGS))
 LDFLAGS  = -p $(PADVALUE)
 FIXFLAGS = -p $(PADVALUE) -v -i "$(GAMEID)" -k "$(LICENSEE)" -l $(OLDLIC) -m $(MBC) -n $(VERSION) -r $(SRAMSIZE) -t $(TITLE)
 

--- a/project.mk
+++ b/project.mk
@@ -40,9 +40,6 @@ ROMEXT  := gb
 # Compilation parameters, uncomment to apply, comment to cancel
 # "Sensible defaults" are included
 
-# Disable automatic `nop` after `halt`
-ASFLAGS += -h
-
 # Export all labels
 # This means they must all have unique names, but they will all show up in the
 # .sym and .map files


### PR DESCRIPTION
It looks like a few options for various rgbds tools were deemed redundant and removed from the latest release. I removed the deprecated options and used the long form for one of them (the short form wasn't recognized anymore).

I tested by just making sure the rom loads up in emulicious.